### PR TITLE
Match key refinements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+* Match key: fixed length title, strip more spec chars, only rightmost 4 digits of date
+
 ## 2.1.0
 
 * Provides `instance-storage-match` interface 2.1

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "instance-storage-match",
-      "version": "2.1",
+      "version": "2.2",
       "handlers": [
         {
           "methods": ["PUT"],

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>mod-inventory-match</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <name>mod-inventory-match</name>
 
   <licenses>

--- a/src/test/java/org/folio/inventorymatch/test/FakeInventoryStorage.java
+++ b/src/test/java/org/folio/inventorymatch/test/FakeInventoryStorage.java
@@ -49,7 +49,11 @@ public class FakeInventoryStorage {
   }
 
   private void initializeStoredInstances() {
-    addStoredInstance(new Instance().setInstanceTypeId("123").setTitle("Initial Instance").setIndexTitle("initial_instance"));
+    addStoredInstance(new Instance().setInstanceTypeId("123").setTitle("Initial Instance").setIndexTitle(normalizeIndexTitle("initial instance")));
+  }
+
+  public static String normalizeIndexTitle(String title) {
+    return String.format("%-70s", title).replace(" ", "_");
   }
 
   private void addStoredInstance(Instance instance) {

--- a/src/test/java/org/folio/inventorymatch/test/InstanceMatchingTestSuite.java
+++ b/src/test/java/org/folio/inventorymatch/test/InstanceMatchingTestSuite.java
@@ -62,9 +62,10 @@ public class InstanceMatchingTestSuite {
   @Test
   public void testPushOfNewInstanceWillCreateNewInstance (TestContext testContext) {
     RestAssured.port = FakeInventoryStorage.PORT_INVENTORY_STORAGE;
+    String indexTitle =  FakeInventoryStorage.normalizeIndexTitle("new title");
     Response instancesBeforePut =
       RestAssured.given()
-        .get(FakeInventoryStorage.URL_INSTANCES+"?query="+ FakeInventoryStorage.encode("indexTitle==\"new_title\""))
+        .get(FakeInventoryStorage.URL_INSTANCES+"?query="+ FakeInventoryStorage.encode("indexTitle==\"" + indexTitle + "\""))
         .then()
         .log().ifValidationFails()
         .statusCode(200).extract().response();
@@ -72,7 +73,7 @@ public class InstanceMatchingTestSuite {
     JsonObject instancesBeforePutJson = new JsonObject(bodyAsStringBeforePut);
 
     testContext.assertEquals(instancesBeforePutJson.getInteger("totalRecords"), 0,
-                             "Number of instance records for query by indexTitle 'new_title' before PUT expected: 0" );
+                             "Number of instance records for query by indexTitle 'new_title___(etc)' before PUT expected: 0" );
 
     Response response;
     RestAssured.port = PORT_INVENTORY_MATCH;
@@ -89,7 +90,7 @@ public class InstanceMatchingTestSuite {
     RestAssured.port = FakeInventoryStorage.PORT_INVENTORY_STORAGE;
     Response instancesAfterPut =
       RestAssured.given()
-        .get(FakeInventoryStorage.URL_INSTANCES+"?query="+ FakeInventoryStorage.encode("indexTitle==\"new_title\""))
+        .get(FakeInventoryStorage.URL_INSTANCES+"?query="+ FakeInventoryStorage.encode("indexTitle==\"" + indexTitle + "\""))
         .then()
         .log().ifValidationFails()
         .statusCode(200).extract().response();
@@ -104,9 +105,10 @@ public class InstanceMatchingTestSuite {
   @Test
   public void testPushOfExistingInstanceWillUpdateExistingInstance (TestContext testContext) {
     RestAssured.port = FakeInventoryStorage.PORT_INVENTORY_STORAGE;
+    String indexTitle =  FakeInventoryStorage.normalizeIndexTitle("initial instance");
     Response instancesBeforePut =
       RestAssured.given()
-        .get(FakeInventoryStorage.URL_INSTANCES+"?query="+ FakeInventoryStorage.encode("indexTitle==\"initial_instance\""))
+        .get(FakeInventoryStorage.URL_INSTANCES+"?query="+ FakeInventoryStorage.encode("indexTitle==\"" + indexTitle + "\""))
         .then()
         .log().ifValidationFails()
         .statusCode(200).extract().response();
@@ -135,7 +137,7 @@ public class InstanceMatchingTestSuite {
     RestAssured.port = FakeInventoryStorage.PORT_INVENTORY_STORAGE;
     Response instancesAfterPut =
       RestAssured.given()
-        .get(FakeInventoryStorage.URL_INSTANCES+"?query="+ FakeInventoryStorage.encode("indexTitle==\"initial_instance\""))
+        .get(FakeInventoryStorage.URL_INSTANCES+"?query="+ FakeInventoryStorage.encode("indexTitle==\"" + indexTitle + "\""))
         .then()
         .log().ifValidationFails()
         .statusCode(200).extract().response();


### PR DESCRIPTION
  - only (4) digits from date of publication
  - replace more special characters
  - remove preceding the, a, an from title
  - limit title+reminder to 70 characters, pad with underscores if less