### PR TITLE
Merge identifiers of a new Instance into the master Instance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 2.3.0
+
+* Merges lists of resource identifiers from the existing and the new instance.
+
 ## 2.2.0
 
 * Match key: fixed length title, strip more spec chars, only rightmost 4 digits of date

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "instance-storage-match",
-      "version": "2.2",
+      "version": "2.3",
       "handlers": [
         {
           "methods": ["PUT"],

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>mod-inventory-match</artifactId>
-  <version>2.2.0-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <name>mod-inventory-match</name>
 
   <licenses>


### PR DESCRIPTION
This is to retain local identifiers for all bib records that are merged into the master.
The local identifiers are meant to be used for referencing the records back in the originating catalogs