### PR TITLE
Fix concurrency issue in OkapiClient usage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 2.4.3
+
+ * Fix concurrency issue introduced with 2.4.1
+
 ## 2.4.2
 
  * Fix NPEs in match key generation

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>mod-inventory-match</artifactId>
-  <version>2.4.2-SNAPSHOT</version>
+  <version>2.4.3-SNAPSHOT</version>
   <name>mod-inventory-match</name>
 
   <licenses>


### PR DESCRIPTION
 - Version 4.2.1 fixed a memory leak by closing OkapiClient connections
   after use. However, in case of multiple concurrent requests, other
   requests could still be using those (shared) connections, which would
   result in an error 500 as the connection was prematurely closed.
   With this commit each request is assigned its own OkapiClient
   connection.